### PR TITLE
Start adding known_race counts in scrapers

### DIFF
--- a/workflow/python/covid19_scrapers/states/alabama.py
+++ b/workflow/python/covid19_scrapers/states/alabama.py
@@ -66,4 +66,6 @@ class Alabama(ScraperBase):
             pct_aa_deaths=aa_deaths_pct,
             pct_includes_unknown_race=False,
             pct_includes_hispanic_black=False,
+            known_race_cases=total_known_cases,
+            known_race_deaths=total_known_deaths,
         )]

--- a/workflow/python/covid19_scrapers/states/alaska.py
+++ b/workflow/python/covid19_scrapers/states/alaska.py
@@ -1,4 +1,4 @@
-from covid19_scrapers.utils import query_geoservice
+from covid19_scrapers.utils import (query_geoservice, to_percentage)
 from covid19_scrapers.scraper import ScraperBase
 
 import logging
@@ -45,15 +45,15 @@ class Alaska(ScraperBase):
 
         # Extract/calculate case info
         total_cases = data.loc['Grand Total', 'Cases']
+        known_cases = data.loc['Known Race', 'Cases']
         aa_cases_cnt = data.loc['Black', 'Cases']
-        # data.loc['Black', 'Cases_Pct'] includes unknown race
-        aa_cases_pct = round(100 * aa_cases_cnt / total_cases, 2)
+        aa_cases_pct = to_percentage(aa_cases_cnt, known_cases, 2)
 
         # Extract/calculate death info
         total_deaths = data.loc['Grand Total', 'Deaths']
+        known_deaths = data.loc['Known Race', 'Deaths']
         aa_deaths_cnt = data.loc['Black', 'Deaths']
-        # data.loc['Black', 'Deaths_Pct'] includes unknown race
-        aa_deaths_pct = round(100 * aa_deaths_cnt / total_deaths, 2)
+        aa_deaths_pct = to_percentage(aa_deaths_cnt, known_deaths, 2)
 
         return [self._make_series(
             date=date,
@@ -63,6 +63,8 @@ class Alaska(ScraperBase):
             aa_deaths=aa_deaths_cnt,
             pct_aa_cases=aa_cases_pct,
             pct_aa_deaths=aa_deaths_pct,
-            pct_includes_unknown_race=True,
+            pct_includes_unknown_race=False,
             pct_includes_hispanic_black=True,
+            known_race_cases=known_cases,
+            known_race_deaths=known_deaths,
         )]

--- a/workflow/python/covid19_scrapers/states/california.py
+++ b/workflow/python/covid19_scrapers/states/california.py
@@ -1,8 +1,10 @@
-from covid19_scrapers.utils import table_to_dataframe, url_to_soup
+from covid19_scrapers.utils import (
+    raw_string_to_int, table_to_dataframe, url_to_soup)
 from covid19_scrapers.scraper import ScraperBase
 
 import datetime
 import logging
+import re
 import string
 
 
@@ -43,13 +45,20 @@ class California(ScraperBase):
         assert len(black_lbl) == 1, f'Unexpected "Black" label in table: {black_lbl}'
         black_lbl = black_lbl[0]
         _logger.debug(f'Black label: {black_lbl}')
-        total_cases = data.loc['Total with data', 'No. Cases']
-        total_deaths = data.loc['Total with data', 'No. Deaths']
+        known_cases = data.loc['Total with data', 'No. Cases']
+        known_deaths = data.loc['Total with data', 'No. Deaths']
         aa_cases = data.loc[black_lbl, 'No. Cases']
         aa_cases_pct = data.loc[black_lbl, 'Percent Cases']
         aa_deaths = data.loc[black_lbl, 'No. Deaths']
         aa_deaths_pct = data.loc[black_lbl, 'Percent Deaths']
 
+        cases_soup = table.find_next('h4', text=re.compile('Cases:'))
+        total_cases = raw_string_to_int(
+            re.search(r'Cases:\s+([0-9,]+)\s+total', cases_soup.text).group(1))
+
+        deaths_soup = table.find_next('h4', text=re.compile('Deaths:'))
+        total_deaths = raw_string_to_int(
+            re.search(r'Deaths:\s+([0-9,]+)\s+total', deaths_soup.text).group(1))
         return [self._make_series(
             date=date,
             cases=total_cases,
@@ -60,4 +69,6 @@ class California(ScraperBase):
             pct_aa_deaths=aa_deaths_pct,
             pct_includes_unknown_race=False,
             pct_includes_hispanic_black=True,
+            known_race_cases=known_cases,
+            known_race_deaths=known_deaths,
         )]

--- a/workflow/python/covid19_scrapers/states/california_san_diego.py
+++ b/workflow/python/covid19_scrapers/states/california_san_diego.py
@@ -6,8 +6,9 @@ import fitz
 from tabula import read_pdf
 
 from covid19_scrapers.census import get_aa_pop_stats
-from covid19_scrapers.utils import download_file, as_list
 from covid19_scrapers.scraper import ScraperBase
+from covid19_scrapers.utils import (
+    as_list, download_file, to_percentage)
 
 
 _logger = logging.getLogger(__name__)
@@ -80,7 +81,7 @@ class CaliforniaSanDiego(ScraperBase):
         total_cases = cases['Count'].sum()
         total_known_cases = cases['Count'].drop(
             'Race/Ethnicity Other/Unknown').sum()
-        cases['Percent'] = round(100 * cases['Count'] / total_known_cases, 2)
+        cases['Percent'] = to_percentage(cases['Count'], total_known_cases)
 
         aa_cases_cnt = cases.loc['Black or African American', 'Count']
         aa_cases_pct = cases.loc['Black or African American', 'Percent']
@@ -115,9 +116,7 @@ class CaliforniaSanDiego(ScraperBase):
         total_known_deaths = (
             total_deaths - deaths.loc['Race/Ethnicity Other/Unknown', 'Count'])
 
-        deaths['Percent'] = round(
-            100 * deaths['Count'] / total_known_deaths, 2
-        )
+        deaths['Percent'] = to_percentage(deaths['Count'], total_known_deaths)
 
         aa_deaths_cnt = deaths.loc['Black or African American', 'Count']
         aa_deaths_pct = deaths.loc['Black or African American', 'Percent']
@@ -137,4 +136,6 @@ class CaliforniaSanDiego(ScraperBase):
             pct_aa_deaths=aa_deaths_pct,
             pct_includes_unknown_race=False,
             pct_includes_hispanic_black=False,
+            known_race_cases=total_known_cases,
+            known_race_deaths=total_known_deaths,
         )]

--- a/workflow/python/covid19_scrapers/states/kentucky.py
+++ b/workflow/python/covid19_scrapers/states/kentucky.py
@@ -105,12 +105,15 @@ class Kentucky(ScraperBase):
         # Since the AA% values do NOT include unknown race counts, we
         # need to omit these when backing out AA case/death counts
         # from the total.
-        aa_cases = round(total_cases
-                         * aa_cases_pct / 100
-                         * cases_known_pct / 100)
-        aa_deaths = round(total_deaths
-                          * aa_deaths_pct / 100
-                          * deaths_known_pct / 100)
+        aa_cases = int(total_cases
+                       * aa_cases_pct / 100
+                       * cases_known_pct / 100)
+        aa_deaths = int(total_deaths
+                        * aa_deaths_pct / 100
+                        * deaths_known_pct / 100)
+
+        known_cases = int(total_cases * cases_known_pct / 100)
+        known_deaths = int(total_deaths * deaths_known_pct / 100)
 
         return [self._make_series(
             date=date,
@@ -122,4 +125,6 @@ class Kentucky(ScraperBase):
             pct_aa_deaths=aa_deaths_pct,
             pct_includes_unknown_race=False,
             pct_includes_hispanic_black=True,
+            known_race_cases=known_cases,
+            known_race_deaths=known_deaths,
         )]

--- a/workflow/python/covid19_scrapers/states/maine.py
+++ b/workflow/python/covid19_scrapers/states/maine.py
@@ -41,15 +41,16 @@ class Maine(ScraperBase):
 
         table = pd.read_excel(url, sheet_name='cases_by_race', index_col=0)
         total_cases = table['CASES'].sum()
-        total_cases_ex_unknown = table['CASES'].drop('Not disclosed').sum()
+        known_cases = table['CASES'].drop('Not disclosed').sum()
         date = table['DATA_REFRESH_DT'].max().date()
         _logger.info(f'Processing data for {date}')
         aa_cases_cnt = table.loc['Black or African American', 'CASES']
-        aa_cases_pct = to_percentage(aa_cases_cnt, total_cases_ex_unknown)
+        aa_cases_pct = to_percentage(aa_cases_cnt, known_cases)
 
         # No race breakdowns for deaths
         aa_deaths_cnt = float('nan')
         aa_deaths_pct = float('nan')
+        known_deaths = float('nan')
 
         return [self._make_series(
             date=date,
@@ -61,4 +62,6 @@ class Maine(ScraperBase):
             pct_aa_deaths=aa_deaths_pct,
             pct_includes_unknown_race=False,
             pct_includes_hispanic_black=True,
+            known_race_cases=known_cases,
+            known_race_deaths=known_deaths,
         )]

--- a/workflow/python/covid19_scrapers/states/missouri.py
+++ b/workflow/python/covid19_scrapers/states/missouri.py
@@ -1,4 +1,5 @@
-from covid19_scrapers.utils import make_geoservice_stat, query_geoservice
+from covid19_scrapers.utils import (
+    make_geoservice_stat, query_geoservice, to_percentage)
 from covid19_scrapers.scraper import ScraperBase
 
 import logging
@@ -52,17 +53,17 @@ class Missouri(ScraperBase):
         # Extract by-race data
         _, cases_race = query_geoservice(**self.RACE_CASE)
         cases_race = cases_race.set_index('RACE')
-        total_known_cases = cases_race.drop(
+        known_cases = cases_race.drop(
             ['REFUSED TO ANSWER RACE', 'UNKNOWN RACE']).sum()['Cases']
         aa_cases = cases_race.loc['BLACK', 'Cases']
-        aa_cases_pct = round(100 * aa_cases / total_known_cases, 2)
+        aa_cases_pct = to_percentage(aa_cases, known_cases)
 
         _, deaths_race = query_geoservice(**self.RACE_DEATH)
         deaths_race = deaths_race.set_index('RACE')
-        total_known_deaths = deaths_race.drop(
+        known_deaths = deaths_race.drop(
             ['REFUSED TO ANSWER RACE', 'UNKNOWN RACE']).sum()['Deaths']
         aa_deaths = deaths_race.loc['BLACK', 'Deaths']
-        aa_deaths_pct = round(100 * aa_deaths / total_known_deaths, 2)
+        aa_deaths_pct = to_percentage(aa_deaths, known_deaths)
 
         return [self._make_series(
             date=date,
@@ -74,4 +75,6 @@ class Missouri(ScraperBase):
             pct_aa_deaths=aa_deaths_pct,
             pct_includes_unknown_race=False,
             pct_includes_hispanic_black=True,
+            known_race_cases=known_cases,
+            known_race_deaths=known_deaths,
         )]

--- a/workflow/python/covid19_scrapers/states/nebraska.py
+++ b/workflow/python/covid19_scrapers/states/nebraska.py
@@ -75,8 +75,10 @@ class Nebraska(ScraperBase):
 
         aa_cases = demog_df.loc['PositiveCases', 'race_AfricanAmerican']
         aa_deaths = demog_df.loc['Deaths', 'race_AfricanAmerican']
-        aa_cases_pct = to_percentage(aa_cases, known_df['PositiveCases'])
-        aa_deaths_pct = to_percentage(aa_deaths, known_df['Deaths'])
+        known_cases = known_df['PositiveCases']
+        known_deaths = known_df['Deaths']
+        aa_cases_pct = to_percentage(aa_cases, known_cases)
+        aa_deaths_pct = to_percentage(aa_deaths, known_deaths)
 
         return [self._make_series(
             date=date,
@@ -88,4 +90,6 @@ class Nebraska(ScraperBase):
             pct_aa_deaths=aa_deaths_pct,
             pct_includes_unknown_race=False,
             pct_includes_hispanic_black=True,
+            known_race_cases=known_cases,
+            known_race_deaths=known_deaths,
         )]

--- a/workflow/python/covid19_scrapers/states/new_york_city.py
+++ b/workflow/python/covid19_scrapers/states/new_york_city.py
@@ -112,4 +112,6 @@ class NewYorkCity(ScraperBase):
             pct_aa_deaths=aa_death_pct,
             pct_includes_unknown_race=False,
             pct_includes_hispanic_black=True,
+            known_race_cases=known_cases,
+            known_race_deaths=known_deaths,
         )]

--- a/workflow/python/covid19_scrapers/states/rhode_island.py
+++ b/workflow/python/covid19_scrapers/states/rhode_island.py
@@ -52,12 +52,11 @@ class RhodeIsland(ScraperBase):
                 aa_cases = int(data.loc[idx, 'Cases'])
                 aa_deaths = int(data.loc[idx, 'Deaths'])
             elif str_idx.startswith('Unknown'):
-                total_known_cases = total_cases - int(data.loc[idx, 'Cases'])
-                total_known_deaths = total_deaths - int(data.loc[idx,
-                                                                 'Deaths'])
+                known_cases = total_cases - int(data.loc[idx, 'Cases'])
+                known_deaths = total_deaths - int(data.loc[idx, 'Deaths'])
         # Compute the percentages as the provided ones are excessively rounded.
-        aa_cases_pct = to_percentage(aa_cases, total_known_cases)
-        aa_deaths_pct = to_percentage(aa_deaths, total_known_deaths)
+        aa_cases_pct = to_percentage(aa_cases, known_cases)
+        aa_deaths_pct = to_percentage(aa_deaths, known_deaths)
 
         return [self._make_series(
             date=date,
@@ -69,4 +68,6 @@ class RhodeIsland(ScraperBase):
             pct_aa_deaths=aa_deaths_pct,
             pct_includes_unknown_race=False,
             pct_includes_hispanic_black=False,
+            known_race_cases=known_cases,
+            known_race_deaths=known_deaths,
         )]

--- a/workflow/python/covid19_scrapers/states/texas_bexar.py
+++ b/workflow/python/covid19_scrapers/states/texas_bexar.py
@@ -1,6 +1,5 @@
 import logging
 
-
 from covid19_scrapers.census import get_aa_pop_stats
 from covid19_scrapers.scraper import ScraperBase
 from covid19_scrapers.utils import (query_geoservice, to_percentage)
@@ -49,8 +48,8 @@ class TexasBexar(ScraperBase):
         _logger.info(f'Processing data for {date_published}')
 
         try:
-            cnt_cases = total.loc[0, 'Cases']
-            cnt_deaths = total.loc[0, 'Deaths']
+            cases = total.loc[0, 'Cases']
+            deaths = total.loc[0, 'Deaths']
         except IndexError:
             raise ValueError('Total count data not found')
 
@@ -60,21 +59,25 @@ class TexasBexar(ScraperBase):
 
         try:
             known = data.sum()
-            cnt_cases_aa = data.loc['Black', 'Cases']
-            cnt_deaths_aa = data.loc['Black', 'Deaths']
-            pct_cases_aa = to_percentage(cnt_cases_aa, known['Cases'])
-            pct_deaths_aa = to_percentage(cnt_deaths_aa, known['Deaths'])
+            cases_aa = data.loc['Black', 'Cases']
+            deaths_aa = data.loc['Black', 'Deaths']
+            known_cases = known['Cases']
+            known_deaths = known['Deaths']
+            pct_cases_aa = to_percentage(cases_aa, known_cases)
+            pct_deaths_aa = to_percentage(deaths_aa, known_deaths)
         except IndexError:
             raise ValueError('No data found for Black RaceEthnicity category')
 
         return [self._make_series(
             date=date_published,
-            cases=cnt_cases,
-            deaths=cnt_deaths,
-            aa_cases=cnt_cases_aa,
-            aa_deaths=cnt_deaths_aa,
+            cases=cases,
+            deaths=deaths,
+            aa_cases=cases_aa,
+            aa_deaths=deaths_aa,
             pct_aa_cases=pct_cases_aa,
             pct_aa_deaths=pct_deaths_aa,
             pct_includes_unknown_race=False,
             pct_includes_hispanic_black=False,
+            known_race_cases=known_cases,
+            known_race_deaths=known_deaths,
         )]

--- a/workflow/python/covid19_scrapers/states/vermont.py
+++ b/workflow/python/covid19_scrapers/states/vermont.py
@@ -66,9 +66,9 @@ class Vermont(ScraperBase):
 
         _, deaths = query_geoservice(**self.RACE_DEATH)
         deaths = deaths.set_index('Race')
+        known_deaths = deaths.drop('Unknown', errors='ignore').sum()['Deaths']
         try:
             aa_deaths_cnt = deaths.loc['Black or African American', 'value']
-            known_deaths = deaths.drop('Unknown').sum()['Deaths']
             aa_deaths_pct = to_percentage(aa_deaths_cnt, known_deaths)
         except KeyError:
             aa_deaths_cnt = 0
@@ -84,4 +84,6 @@ class Vermont(ScraperBase):
             pct_aa_deaths=aa_deaths_pct,
             pct_includes_unknown_race=False,
             pct_includes_hispanic_black=True,
+            known_race_cases=known_cases,
+            known_race_deaths=known_deaths,
         )]

--- a/workflow/python/covid19_scrapers/states/washington.py
+++ b/workflow/python/covid19_scrapers/states/washington.py
@@ -1,4 +1,5 @@
-from covid19_scrapers.utils import table_to_dataframe, url_to_soup
+from covid19_scrapers.utils import (
+    table_to_dataframe, to_percentage, url_to_soup)
 from covid19_scrapers.scraper import ScraperBase
 
 import datetime
@@ -58,16 +59,20 @@ class Washington(ScraperBase):
         # Extract the data
         total_cases = cases.loc['Total Number of Cases',
                                 'Confirmed Cases']
+        known_cases = cases.loc['Total with Race/Ethnicity Available',
+                                'Confirmed Cases']
         aa_cases = cases.loc['Non-Hispanic Black', 'Confirmed Cases']
-        aa_cases_pct = cases.loc['Non-Hispanic Black', 'Percent of Cases']
+        aa_cases_pct = to_percentage(aa_cases, known_cases)
 
         deaths_div = soup.find(id='pnlDeathsByRaceTbl')
         deaths = table_to_dataframe(
             deaths_div.find('table')).set_index('Race/Ethnicity')
         deaths.columns = deaths.columns.str.replace('\xa0.*', '')
         total_deaths = deaths.loc['Total Number of Deaths', 'Deaths']
+        known_deaths = deaths.loc['Total with Race/Ethnicity Available',
+                                  'Deaths']
         aa_deaths = deaths.loc['Non-Hispanic Black', 'Deaths']
-        aa_deaths_pct = deaths.loc['Non-Hispanic Black', 'Percent of Deaths']
+        aa_deaths_pct = to_percentage(aa_deaths, known_deaths)
 
         return [self._make_series(
             date=date,
@@ -79,4 +84,6 @@ class Washington(ScraperBase):
             pct_aa_deaths=aa_deaths_pct,
             pct_includes_unknown_race=False,
             pct_includes_hispanic_black=False,
+            known_race_cases=known_cases,
+            known_race_deaths=known_deaths,
         )]

--- a/workflow/python/covid19_scrapers/states/wisconsin.py
+++ b/workflow/python/covid19_scrapers/states/wisconsin.py
@@ -58,4 +58,6 @@ class Wisconsin(ScraperBase):
             pct_aa_deaths=aa_deaths_pct,
             pct_includes_unknown_race=False,
             pct_includes_hispanic_black=True,
+            known_race_cases=known_cases,
+            known_race_deaths=known_deaths,
         )]


### PR DESCRIPTION
This fixes #10 for now -- for (almost) all the scrapers with `pct_includes_unknown_race=False` (and 3 more I switched to that), I updated them to add two more fields, `known_race_cases` and `known_race_deaths` so clients can reproduce our calculations for Black/AA percentages, since these may differ from published versions that include unknown race in the denominator.