### PR TITLE
Webcache init

### DIFF
--- a/workflow/python/covid19_scrapers/scoped_resource.py
+++ b/workflow/python/covid19_scrapers/scoped_resource.py
@@ -1,3 +1,9 @@
+import logging
+
+
+_logger = logging.getLogger(__name__)
+
+
 class ScopedResource(object):
     """This is a helper to make a class usable in a pattern like this:
 
@@ -19,25 +25,32 @@ class ScopedResource(object):
 
     """
 
-    def __init__(self, cls):
+    def __init__(self, cls, *args, **kwargs):
         self.cls = cls
         self.instance = None
+        self.args = args
+        self.kwargs = kwargs
 
     def __call__(self, *args, **kwargs):
+        _logger.debug('Creating new instance: '
+                      f'{self.cls.__name__}(*args={args}, **kwargs={kwargs})')
         self.args = args
         self.kwargs = kwargs
         return self
 
     def with_instance(self, instance):
-        assert isinstance(instance, self.cls), 'Invalid argument type'
+        assert isinstance(instance, self.cls), 'Invalid argument type: got {instance.__class__.__name__}, expected {self.cls.__name__}'
+        _logger.debug(f'Setting {self.cls.__name__} instance: {instance}')
         self.instance = instance
         return self
 
     def __enter__(self):
         if not self.instance:
             self.instance = self.cls(*self.args, **self.kwargs)
+        _logger.debug(f'Entering {self.cls.__name__} scope: {self.instance}')
 
     def __exit__(self, exc_type, exc_value, traceback):
+        _logger.debug(f'Exiting {self.cls.__name__} scope: {self.instance}')
         self.instance = None
 
     def __getattr__(self, name):

--- a/workflow/python/covid19_scrapers/utils/__init__.py
+++ b/workflow/python/covid19_scrapers/utils/__init__.py
@@ -8,4 +8,7 @@ from covid19_scrapers.scoped_resource import ScopedResource
 #
 #    with utils.UTILS_WEB_CACHE('my_cache.db'):
 #        code_that_might_call_utils()
-UTILS_WEB_CACHE = ScopedResource(WebCache)
+#
+# It is initialized with an in-memory cache, which is discarded the
+# first time it is set using `with`.
+UTILS_WEB_CACHE = ScopedResource(WebCache).with_instance(WebCache(':memory:'))

--- a/workflow/python/covid19_scrapers/web_cache.py
+++ b/workflow/python/covid19_scrapers/web_cache.py
@@ -20,14 +20,21 @@ class WebCache(object):
 
     def __init__(self, db_name='web_cache.db', reset=False):
         # Set up DB connection.
+        _logger.info(f'Connecting web cache to DB: {db_name}')
+        self.db_name = db_name
         self.conn = sqlite3.connect(db_name)
         self.conn.row_factory = sqlite3.Row
         self.cursor = self.conn.cursor()
         if reset:
+            _logger.debug('Resetting DB table')
             self.cursor.execute('DROP TABLE IF EXISTS web_cache')
+        _logger.debug('Creating DB table')
         self.cursor.execute(
             'CREATE TABLE IF NOT EXISTS web_cache\n'
             f'({", ".join(self.SCHEMA)})')
+
+    def __repr__(self):
+        return f'<{self.__class__.__name__} db={self.db_name}>'
 
     def delete_from_cache(self, where):
         """Remove the requested rows from the cache.


### PR DESCRIPTION
This makes the initial value for `utils.UTILS_WEB_CACHE` an in-memory `WebCache` instance, so that the utils that call `get_cached_url` can run without having set it up with a `with UTILS_WEB_CACHE(...):`, e.g., in testcases. 

Also adds some logging  to `WebCache` and `ScopedResource`