### PR TITLE
Cache enhancements

### DIFF
--- a/workflow/python/covid19_scrapers/census/census_api.py
+++ b/workflow/python/covid19_scrapers/census/census_api.py
@@ -65,7 +65,7 @@ class CensusApi(object):
         names.
 
         """
-        resp = get_json(url + f'/groups/{group}.json')
+        resp = get_json(url + f'/groups/{group}.json', force_cache=True)
         for val in resp['variables'].values():
             if val.get('concept'):
                 concept = val['concept']
@@ -99,7 +99,7 @@ class CensusApi(object):
         else:
             _logger.warn('Calling Census API without a key: '
                          'Be careful of hitting the rate limit.')
-        results = get_content_as_file(url, params=params)
+        results = get_content_as_file(url, params=params, force_cache=True)
 
         # Get group field to name mappings
         fields = dict(fields)  # Make a copy.

--- a/workflow/python/covid19_scrapers/web_cache.py
+++ b/workflow/python/covid19_scrapers/web_cache.py
@@ -1,4 +1,6 @@
 # Helpers for cached HTTP data retrieval.
+import datetime
+import email.utils as eut
 import logging
 import pickle
 import sqlite3
@@ -8,6 +10,72 @@ import requests
 
 
 _logger = logging.getLogger(__name__)
+
+
+def get_current_age(response):
+    """Approximate RFC 2616 calculations for cached page age in seconds."""
+    now = datetime.datetime.now(datetime.timezone.utc)
+    date = response.headers.get('date') or response.headers.get('date')
+    if date:
+        date_value = eut.parsedate_to_datetime(date)
+    else:
+        # No date; fall back to a default that will cause revalidation.
+        date_value = datetime.datetime.fromtimestamp(0, datetime.timezone.utc)
+    initial_age = max(float(response.headers.get('age', 0)),
+                      response.elapsed.total_seconds())
+    resident_time = (now - date_value).total_seconds()
+    current_age = initial_age + resident_time
+    return current_age
+
+
+def parse_cache_control(response):
+    cache_control = {}
+    for item in response.headers.get('cache-control', '').split(','):
+        idx = item.find('=')
+        if idx >= 0:
+            cache_control[item[:idx].strip()] = item[idx + 1:].strip()
+        else:
+            cache_control[item.strip()] = True
+    return cache_control
+
+
+def get_freshness_lifetime(response):
+    """Perform RFC 2616 calculations for freshness lifetime."""
+    # Parse the cache-control header
+    cache_control = parse_cache_control(response)
+
+    # If there is a no-cache cache control, check the server.
+    if cache_control.get('no-cache'):
+        return 0.0
+
+    # If there is a max-age cache control, use it.
+    max_age = cache_control.get('max-age')
+    if max_age is not None:
+        return float(max_age)
+
+    # Fall back to Expires, if present.
+    expires = response.headers.get('expires')
+    if expires is not None:
+        date_value = eut.parsedate_to_datetime(
+            response.headers['date'])
+        max_age = (eut.parsedate_to_datetime(expires)
+                   - date_value).total_seconds()
+        return max_age
+
+    # Fall back to 4 hours, otherwise.
+    return 4 * 3600.0
+
+
+def is_fresh(response):
+    """Perform RFC 2616 calculations for page expiration."""
+    lifetime = get_freshness_lifetime(response)
+    age = get_current_age(response)
+    if lifetime > age:
+        _logger.debug(f'Response is fresh: max_age={lifetime} > age={age}')
+        return True
+    else:
+        _logger.debug(f'Response is stale: max_age={lifetime} <= age={age}')
+        return False
 
 
 class WebCache(object):
@@ -61,13 +129,28 @@ class WebCache(object):
                 resp['response'] = pickle.loads(resp['response'])
             return resp
 
-    def cache_response(self, url, response):
+    def cache_response(self, url, response, force_cache):
+        cache_control = parse_cache_control(response)
+        if cache_control.get('no-store'):
+            if not force_cache:
+                _logger.debug('Skipping cache: response has '
+                              'Cache-Control: no-store')
+                return
+            _logger.debug('Caching: response has Cache-Control: no-store, '
+                          'but force_cache is set')
+
         etag = response.headers.get('etag')
         last_modified = response.headers.get('last-modified')
         if etag is None and last_modified is None:
-            _logger.debug(f'Unable to cache {url}: '
-                          'No ETag or Last-Modified header returned')
-            return
+            if force_cache:
+                last_modified = eut.format_datetime(
+                    datetime.datetime.now(datetime.timezone.utc))
+                _logger.debug('Forcing URL into cache with '
+                              f'last-modified={last_modified}')
+            else:
+                _logger.debug(f'Unable to cache {url}: '
+                              'No ETag or Last-Modified header returned')
+                return
         self.cursor.execute(
             'INSERT OR REPLACE INTO web_cache VALUES'
             ' (:url, :etag, :last_modified, :response)',
@@ -79,16 +162,32 @@ class WebCache(object):
             })
         self.conn.commit()
 
-    def fetch(self, url, force_remote=False, cache_only=False,
-              method='GET', headers={}, params={}, data={},
-              files={}, cookies={}, session=None, session_kwargs={},
-              **kwargs):
+    def touch_response(self, cache_key, cached_response, new_headers):
+        """Update the headers in the cached response for cache freshness."""
+        cached_response.headers.update(new_headers)
+        self.cursor.execute(
+            'UPDATE web_cache '
+            'SET response=:response '
+            'WHERE url=:url',
+            {
+                'url': cache_key,
+                'response': pickle.dumps(cached_response),
+            })
+        self.conn.commit()
+
+    def fetch(self, url, force_remote=False, force_cache=False,
+              cache_only=False, method='GET', headers={}, params={},
+              data={}, files={}, cookies={}, session=None,
+              session_kwargs={}, **kwargs):
         """Retrieve a URL from the cache, or retrieve the URL from the web and
         store the response into a cache.
 
         Arguments:
           url: the URL to retrieve.
           force_remote: if True, retrieve the URL without using the cache.
+          force_cache: if True, store the URL contents into the cache
+            when not present, regardless of missing Last-Modified or
+            ETag headers.
           cache_only: if True, only retrieve the URL from the cache.
           method: the HTTP method to use. Only GET requests are cached.
           headers: request headers.
@@ -113,32 +212,55 @@ class WebCache(object):
         # fragment.
         cache_key, _ = urldefrag(request.url)
         cached = None
-        # Only use cache for GETs
-        if method == 'GET' and not force_remote:
-            cached = self.get_cached_response(cache_key)
-            if cached:
-                _logger.debug(f'cache hit: {cache_key}')
-                if cached['etag']:
-                    request.headers['If-None-Match'] = cached['etag']
-                if cached['last_modified']:
-                    request.headers['If-Modified-Since'] = \
-                        cached['last_modified']
-            else:
-                _logger.debug(f'cache miss for {cache_key}')
-        if cache_only:
-            if cached:
-                return cached['response']
-            raise RuntimeError(f'Cache miss with cache_only set: {cache_key}')
+        revalidating = False
 
+        # HTTP only cache GETs
+        if method != 'GET' or force_remote:
+            response = session.send(request)
+            response.raise_for_status()
+            return response
+
+        cached = self.get_cached_response(cache_key)
+        if cached:
+            _logger.debug(f'Found cache entry: {cache_key}')
+            # Are we demanding the cached value?
+            if cache_only:
+                _logger.debug('Requested cache_only: returning cached'
+                              ' response')
+                return cached['response']
+            # Do we know the cached value is good without revalidating?
+            if is_fresh(cached['response']):
+                _logger.debug('Cache hit: returning cached response')
+                return cached['response']
+            # Prepare to revalidate.
+            _logger.debug('Revalidating stale cached response')
+            if cached['etag']:
+                revalidating = True
+                request.headers['If-None-Match'] = cached['etag']
+            if cached['last_modified']:
+                revalidating = True
+                request.headers['If-Modified-Since'] = \
+                    cached['last_modified']
+        else:
+            _logger.debug(f'Cache miss: {cache_key}')
+            if cache_only:
+                raise RuntimeError('Cache miss with cache_only set: '
+                                   f'{cache_key}')
+
+        # For cache misses and revalidation, we need to contact the server.
         _logger.debug(f'Sending request: {url}')
         response = session.send(request)
-        if response.status_code == 304:
-            # We can only get 304 for conditional GETs, so we know
-            # cached is valid.
-            _logger.debug(f'Using cached response: {cache_key}')
-            return cached['response']
+
+        if revalidating:
+            if response.status_code == 304:
+                _logger.debug('Still valid: returning cached response')
+                # Update the cached headers
+                self.touch_response(cache_key, cached['response'],
+                                    response.headers)
+                return cached['response']
+            _logger.debug('No longer valid; replacing cached response')
+
         response.raise_for_status()
-        if cached:
-            _logger.debug('Cached response is stale')
-        self.cache_response(cache_key, response)
+        self.cache_response(cache_key, response, force_cache=force_cache)
+        response.headers['x-new-response'] = '1'
         return response


### PR DESCRIPTION
This makes a few changes to `web_cache.py`, primarily to improve Census API performance:
* Adds a "freshness" check to cached responses. If the response has been resident in the cache for less than the "freshness lifetime", we return it without making a conditional GET to revalidate with the server that it is up-to-date.
* Refactors `fetch` routine to be clearer using early returns.
* Updates cached document headers after revalidation.
* Adds a `force_cache` option to let us cache census API calls.

And updates `census_api.py` to add the `force_cache` option.