### PR TITLE
Initial prototype for multiday scraping

### DIFF
--- a/workflow/python/covid19_scrapers/scraper.py
+++ b/workflow/python/covid19_scrapers/scraper.py
@@ -25,7 +25,9 @@ class ScraperBase(object):
             if it does not exist.
 
           census_api: instance of
-            covid19_scrapers.census_api.CensusApi
+            covid19_scrapers.census_api.CensusApi.
+          start_date: start date for scraper output, or None.
+          end_date: end date for scraper output.
 
         """
         self.home_dir = home_dir
@@ -39,7 +41,7 @@ class ScraperBase(object):
         """
         return self.__class__.__name__
 
-    def run(self, **kwargs):
+    def run(self, start_date, end_date, **kwargs):
         """Invoke the subclass's _scrape method and return the result or an
         error row. _scrape must return a list (possibly empty) of
         pandas Series objects, or a DataFrame.
@@ -50,7 +52,8 @@ class ScraperBase(object):
         with dir_context(self.home_dir):
             try:
                 _logger.info(f'Scraping {self.name()}')
-                rows = self._scrape(**kwargs)
+                rows = self._scrape(start_date=start_date, end_date=end_date,
+                                    **kwargs)
             except Exception as e:
                 rows = self._handle_error(e)
         return pd.DataFrame(rows)


### PR DESCRIPTION
For #7 
The idea is to add `--start_date` and `--end_date` options, which get passed into `ScraperBase.run` and `_scrape`, resp.
Scrapers that can provide data for days between those dates, inclusive, should do so.
CA offers a fairly simple demo.