### PR TITLE
Missippi: Ignore extraneous report with no date in title

### DIFF
--- a/workflow/python/covid19_scrapers/states/mississippi.py
+++ b/workflow/python/covid19_scrapers/states/mississippi.py
@@ -35,12 +35,13 @@ class Mississippi(ScraperBase):
         # Dictionary from dates associated to their PDF links
         links_by_date = {}
         for link, title in title_dict.items():
-            # Some entries omit the comma in the as-of date
-            month, day, year = re.search(r'as of ([A-Z][a-z]+) (\d+),? (\d+)',
-                                         title).groups()
-            dt = datetime.datetime.strptime(f'{month} {day}, {year}',
-                                            '%B %d, %Y').date()
-            links_by_date[dt] = link
+            if 'Incidence and Cases' not in title:
+                # Some entries omit the comma in the as-of date
+                month, day, year = re.search(r'as of ([A-Z][a-z]+) (\d+),? (\d+)',
+                                             title).groups()
+                dt = datetime.datetime.strptime(f'{month} {day}, {year}',
+                                                '%B %d, %Y').date()
+                links_by_date[dt] = link
 
         # Find the most recent link
         date = max(links_by_date)


### PR DESCRIPTION
The report archive page now has an extraneous file called `Mississippi Counties Ranked by COVID-19 Weekly Incidence and Cases`. 

The code was expecting titles of the form `Mississippi COVID-19 Cases and Deaths by County as of <month> <day>, <year>`, so this new file causes an error.

I modified the logic so that it ignores this file so that I could get the scraper running again. 

If you own the Mississippi scraper, feel free to modify the logic so that it aligns with your standards.