### PR TITLE
Fix Maine scraper

### DIFF
--- a/workflow/python/covid19_scrapers/states/maine.py
+++ b/workflow/python/covid19_scrapers/states/maine.py
@@ -1,9 +1,8 @@
+import datetime
 import logging
 import pandas as pd
-import re
 
 from covid19_scrapers.scraper import ScraperBase
-from covid19_scrapers.utils.html import url_to_soup
 from covid19_scrapers.utils.misc import to_percentage
 
 
@@ -12,38 +11,26 @@ _logger = logging.getLogger(__name__)
 
 class Maine(ScraperBase):
     """Maine publishes demographic breakdowns of COVID cases (not yet
-    deaths) in a Google Sheet. We scrape their main reporting page to
-    find the link in case it changes.
+    deaths) in CSV files. These files contain the up to date info only,
+    no historical data is given.
 
+    The homepage URL is:
+    https://www.maine.gov/dhhs/mecdc/infectious-disease/epi/airborne/coronavirus/data.shtml
     """
-    REPORT_URL = 'https://www.maine.gov/dhhs/mecdc/infectious-disease/epi/airborne/coronavirus/data.shtml'
+    CASES_BY_COUNTY_URL = 'https://gateway.maine.gov/dhhs-apps/mecdc_covid/cases_by_county.csv'
+    CASES_BY_RACE_URL = 'https://gateway.maine.gov/dhhs-apps/mecdc_covid/cases_by_race.csv'
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-    @staticmethod
-    def __find_table(tables, title):
-        """Find a table with a child whose text contains title."""
-        title_re = re.compile(title)
-        for table in tables:
-            if table.find(text=title_re):
-                return table
-
     def _scrape(self, **kwargs):
-        # Download the data
-        soup = url_to_soup(self.REPORT_URL)
-
-        # Find the Google sheet
-        url = soup.find('a', string=re.compile('Google Sheet', re.I))['href']
-        url = re.sub(r'(.*)/edit\b.*', r'\1/export?format=xlsx', url)
-        _logger.debug(f'Sheets URL is {url}')
-        counties = pd.read_excel(url, sheet_name='cases_by_county')
+        counties = pd.read_csv(self.CASES_BY_COUNTY_URL)
         total_deaths = counties['DEATHS'].sum()
 
-        table = pd.read_excel(url, sheet_name='cases_by_race', index_col=0)
+        table = pd.read_csv(self.CASES_BY_RACE_URL, index_col=0)
         total_cases = table['CASES'].sum()
         known_cases = table['CASES'].drop('Not disclosed').sum()
-        date = table['DATA_REFRESH_DT'].max().date()
+        date = datetime.datetime.strptime(table['DATA_REFRESH_DT'][0], '%Y-%m-%d').date()
         _logger.info(f'Processing data for {date}')
         aa_cases_cnt = table.loc['Black or African American', 'CASES']
         aa_cases_pct = to_percentage(aa_cases_cnt, known_cases)

--- a/workflow/python/covid19_scrapers/states/maine.py
+++ b/workflow/python/covid19_scrapers/states/maine.py
@@ -1,8 +1,8 @@
-import datetime
 import logging
 import pandas as pd
 
 from covid19_scrapers.scraper import ScraperBase
+from covid19_scrapers.utils.http import get_content_as_file
 from covid19_scrapers.utils.misc import to_percentage
 
 
@@ -27,10 +27,14 @@ class Maine(ScraperBase):
         counties = pd.read_csv(self.CASES_BY_COUNTY_URL)
         total_deaths = counties['DEATHS'].sum()
 
-        table = pd.read_csv(self.CASES_BY_RACE_URL, index_col=0)
+        table = pd.read_csv(
+            get_content_as_file(self.CASES_BY_RACE_URL),
+            index_col=0,
+            parse_dates=['DATA_REFRESH_DT'])
+
         total_cases = table['CASES'].sum()
         known_cases = table['CASES'].drop('Not disclosed').sum()
-        date = datetime.datetime.strptime(table['DATA_REFRESH_DT'][0], '%Y-%m-%d').date()
+        date = table['DATA_REFRESH_DT'][0].date()
         _logger.info(f'Processing data for {date}')
         aa_cases_cnt = table.loc['Black or African American', 'CASES']
         aa_cases_pct = to_percentage(aa_cases_cnt, known_cases)


### PR DESCRIPTION
Fixes #170

The data has moved off of Google Sheets and they seem to be providing data via their own URL now (maybe it's an abstracted out Google Sheet? Either way, it doesn't seem like they want us to touch it.)

----

Before, there was some code that would dynamically find the URL in case something changes. Which would make the scraper more robust. I took it out and made it static instead.  

I want to share why, but also wanted to maybe hear an opposite point of view?

So, based on seeing how the landscape of how COVID data is made available to the public, it seems like there are many things that are still in flux (i.e. field names, data format, urls, etc). My thinking is that even though we can make certain parts of this code dynamic and less prone to breaking, it's hard to have a good heuristic on how likely something is or isn't to change. I.e. it's possible that dynamically searching for parts of the code we intuitively think will change, may not be the thing that changes and breaks the code. In which case, the code needs to be updated anyway.

I think maybe it makes sense to leave things static for now and maybe come up with a possible generalized solution for this later down the road?

But I'm also curious about another POV!