### PR TITLE
Fix NY and NYC scrapers

### DIFF
--- a/workflow/python/covid19_scrapers/states/new_york.py
+++ b/workflow/python/covid19_scrapers/states/new_york.py
@@ -20,7 +20,7 @@ class NewYork(ScraperBase):
     SUMMARY_URL = 'https://covid19tracker.health.ny.gov/views/NYS-COVID19-Tracker/NYSDOHCOVID-19Tracker-TableView?%3Aembed=yes&%3Atoolbar=no&%3Atabs=n'
     DEATHS_URL = 'https://covid19tracker.health.ny.gov/views/NYS-COVID19-Tracker/NYSDOHCOVID-19Tracker-Fatalities?%3Aembed=yes&%3Atoolbar=no&%3Atabs=n'
     NYS_RACE_DEATHS_URL = 'https://covid19tracker.health.ny.gov/views/NYS-COVID19-Tracker/NYSDOHCOVID-19Tracker-FatalityDetail?%3Aembed=yes&%3Atoolbar=no&%3Atabs=n'
-    NYC_RACE_DEATHS_URL = 'https://raw.githubusercontent.com/nychealth/coronavirus-data/master/by-race.csv'
+    NYC_RACE_DEATHS_URL = 'https://raw.githubusercontent.com/nychealth/coronavirus-data/master/totals/by-race.csv'
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/workflow/python/covid19_scrapers/states/new_york_city.py
+++ b/workflow/python/covid19_scrapers/states/new_york_city.py
@@ -26,7 +26,7 @@ class NewYorkCity(ScraperBase):
 
     def name(self):
         return 'New York -- New York'
-    
+
     @classmethod
     def is_beta(cls):
         return getattr(cls, 'BETA_SCRAPER', True)
@@ -48,7 +48,7 @@ class NewYorkCity(ScraperBase):
 
         _logger.debug('Fetching latest summary data')
         latest_cases = pd.read_csv(
-            BytesIO(repo.get_contents('summary.csv').decoded_content),
+            BytesIO(repo.get_contents('totals/summary.csv').decoded_content),
             header=None,
             names=['key', 'value'],
             index_col=0)
@@ -93,7 +93,7 @@ class NewYorkCity(ScraperBase):
 
         _logger.debug(f'Fetching demographic data for {max_date}')
         latest_demog = pd.read_csv(
-            BytesIO(repo.get_contents('by-race.csv', ref=sha).decoded_content),
+            BytesIO(repo.get_contents('totals/by-race.csv', ref=sha).decoded_content),
             index_col='RACE_GROUP'
         )
         aa_cases = latest_demog.loc['Black/African-American', 'CASE_COUNT']


### PR DESCRIPTION
Fixes #172

The path for NYC data on their GitHub has changed. This fix updates to the new path.